### PR TITLE
Keep defaults - and future changes to vim-config

### DIFF
--- a/.vim/common_config/key_mappings.vim
+++ b/.vim/common_config/key_mappings.vim
@@ -74,7 +74,3 @@
 " CTRL-V and SHIFT-Insert are Paste
   map <S-Insert> "+gP
   cmap <S-Insert> cmap<C-R>+
-
-" CTRL-Z is Undo; not in cmdline though
-  noremap <C-Z> u
-  inoremap <C-Z> <C-O>u

--- a/.vim/common_config/key_mappings.vim
+++ b/.vim/common_config/key_mappings.vim
@@ -58,7 +58,6 @@
   map N Nzz
   map <C-o> <C-o>zz
   map <C-i> <C-i>zz
-  nnoremap ; :
 
 " PHP
   imap <C-l> ->


### PR DESCRIPTION
1. Guys - the keymapping changes broke some pretty standard VIM functionality - specifically the ability to repeat search & the ability to background vim when in command line mode. I am not against some keymaps that make some tasks easier - but when for ease of use we remove functions I don't think its justified.  

Is it ok if I merge these changes below to bring back the missing functionality ?

2. Also is it ok if in the future we create pull requests before making changes - just so that we can discuss them first. I feel its useful to have a  vim-config that everyone in the office is good at using. To achieve that we are going to need to have a more consensus based approach to making changes.

What do you guys think about PRs for all future changes (not bug fixes) to vim-config ?

@ata @guiltry @passport90 