### PR TITLE
Fix appending cmap while paste to commandline in gvim

### DIFF
--- a/.vim/common_config/key_mappings.vim
+++ b/.vim/common_config/key_mappings.vim
@@ -73,4 +73,4 @@
 
 " CTRL-V and SHIFT-Insert are Paste
   map <S-Insert> "+gP
-  cmap <S-Insert> cmap<C-R>+
+  cmap <S-Insert> <C-R>+


### PR DESCRIPTION
If you trying paste something <shift insert> to command in gvim (For example you try to opening a path in gvim), it will appending the 'cmap'

This issue doesn't occurs in vim terminal only in gvim
Does this occurs in mvim?