### PR TITLE
Add fzf with backward compatible

### DIFF
--- a/.vim/common_config/01_plugin_config.vim
+++ b/.vim/common_config/01_plugin_config.vim
@@ -42,6 +42,13 @@
       let g:ctrlp_user_command = ['.git', 'cd %s && git ls-files . --cached --exclude-standard --others']
     endif
 
+"FZF
+  " Bundle "junegunn/fzf.git"
+  " use fzf if ~/.fzf present, else keep the CtrlP
+    if !empty(glob("~/.fzf/bin/fzf"))
+      nnoremap <Leader>t :<C-U>FZF<CR>
+    endif
+
 " Slim
   Bundle "slim-template/vim-slim.git"
     au BufNewFile,BufRead *.slim set filetype=slim

--- a/.vimrc
+++ b/.vimrc
@@ -1,4 +1,7 @@
 set rtp+=~/.vim/bundle/Vundle.vim/
+if !(empty(glob("~/.fzf/bin/fzf"))
+  set rtp+=~/.fzf
+endif
 
 runtime! custom_preconfig/*.vim
 runtime! common_config/*.vim


### PR DESCRIPTION
This will replace CtrlP fuzzy search with [fzf](https://github.com/junegunn/fzf).
Advantage of fzf is:
1. Better searching (ctrlp seems having wildchart issue)
eg: if you search foobar ctrlp will prioritize faaooaabaaar instead of foobar but fzf will prioritize the nearest character first.
2. No need to refresh if any file added or deleted

Disadvantage of fzf:
1. If you use gvim, it not integrated with the gui, but it use the xterm for opening search window (this issue is not a problem if you use vim / nvim. ps: nvim is the best)

If you are not using the fzf, don't worry, it will keep the ctrl p as the default searching.
And also you can still use buffer opener (Leader B) from ctrlp as well =)