### PR TITLE
Add vim-indent-guides to see the indentation color

### DIFF
--- a/.pairs
+++ b/.pairs
@@ -41,6 +41,7 @@ pairs:
   jun: Junita Sinambela
   ad: Adrian Setyadi
   sdc: Septhianto Diga Chandra
+  kp: Kevin Prathama Iskandar
 email:
   prefix: pair
   domain: kmkonline.co.id

--- a/.vim/common_config/01_plugin_config.vim
+++ b/.vim/common_config/01_plugin_config.vim
@@ -202,6 +202,9 @@ call plug#begin('~/.vim/plugged')
   autocmd FileType xbt.php set tabstop=2|set softtabstop=2|set shiftwidth=2
   au BufEnter *.xbt.php set ai sw=2 ts=2 sta et fo=croql
 
+" Color indentation
+  Plug 'nathanaelkane/vim-indent-guides'
+
   Plug 'janko-m/vim-test'
 
   function! s:cat(filename) abort


### PR DESCRIPTION
Adding plugin vim-indent-guides to add color to indentation.

**Usage:**
Use `<Leader>ig` to toggle.


Don't worry! You can thank us later. - KP & AD